### PR TITLE
Add support for newer (>3.8) python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 setup(
     name="olc",
     # PEP-440 compatible version
-    version="0.0.3",
+    version="0.0.4",
     url="https://github.com/rommelag/olc",
     author="Rommelag iLabs",
     description=("Basic Open Source License Collector"),


### PR DESCRIPTION
Looks like the pip internals changed, so accessing it the 'old' way no longer works. Instead use importlib.metadata if available, and also add support for importlib_metadata backport (if installed).

Also see https://stackoverflow.com/questions/49923671/are-there-any-function-replacement-for-pip-get-installed-distributions-in-pip